### PR TITLE
Various upgrades and modernisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 composer.lock
 composer.phar
 phpunit.xml
+.phpunit.result.cache
+
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 
 php:
- - "5.3"
- - "5.4"
- - "5.5"
+ - "7.4"
+ - "8.0"
 
 before_script:
  - composer self-update
  - composer --version
  - composer install -n --dev --prefer-source
 
-script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text
+script: composer run lint:check && composer run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
     vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text
     ```
 
-    The [Travis CI build](https://travis-ci.org/justinbusschau/php-govtalk) runs on PHP `5.3`, `5.4` and `5.5`.
+    The [Travis CI build](https://travis-ci.org/thebiggive/php-govtalk) runs on PHP 7.4 and 8.0.
 
 * Commit the modifications to your own forked repo in your topic branch.
 * Ensure your code is nicely formatted in the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ it to your `composer.json` file:
 ```json
 {
     "require": {
-        "justinbusschau/php-govtalk": "0.*"
+        "justinbusschau/php-govtalk": "^1.0"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 **A library for applications which interface with the UK Government Gateway**
 
-[![Build Status](https://travis-ci.org/JustinBusschau/php-govtalk.png?branch=master)](https://travis-ci.org/JustinBusschau/php-govtalk)
-[![Latest Stable Version](https://poser.pugx.org/justinbusschau/php-govtalk/version.png)](https://packagist.org/packages/justinbusschau/php-govtalk)
-[![Total Downloads](https://poser.pugx.org/justinbusschau/php-govtalk/d/total.png)](https://packagist.org/packages/justinbusschau/php-govtalk)
-[![License](https://poser.pugx.org/justinbusschau/php-govtalk/license.svg)](https://packagist.org/packages/justinbusschau/php-govtalk)
+[![Build Status](https://travis-ci.org/thebiggive/php-govtalk.png?branch=main)](https://travis-ci.org/thebiggive/php-govtalk)
+[![Latest Stable Version](https://poser.pugx.org/thebiggive/php-govtalk/version.png)](https://packagist.org/packages/thebiggive/php-govtalk)
+[![Total Downloads](https://poser.pugx.org/thebiggive/php-govtalk/d/total.png)](https://packagist.org/packages/thebiggive/php-govtalk)
+[![License](https://poser.pugx.org/thebiggive/php-govtalk/license.svg)](https://packagist.org/packages/thebiggive/php-govtalk)
 
 The GovTalk Message Envelope is a standard developed by the United Kingdom government as a means of encapsulating
 a range of government XML services in a single standard data format.
@@ -22,7 +22,7 @@ it to your `composer.json` file:
 ```json
 {
     "require": {
-        "justinbusschau/php-govtalk": "^1.0"
+        "thebiggive/php-govtalk": "^1.0"
     }
 }
 ```
@@ -40,4 +40,4 @@ Document Submission Protocol. The following libraries currently use / extend Gov
 
 Library | Composer Package | Maintainer
 --- | --- | ---
-[HMRC Gif Aid](https://github.com/justinbusschau/hmrc-gift-aid) | justinbusschau/hmrc-gift-aid | [Justin Busschau](https://github.com/justinbusschau)
+[HMRC Gift Aid](https://github.com/thebiggive/hmrc-gift-aid) | thebiggive/hmrc-gift-aid | [Noel Light-Hilary](https://github.com/noellh)

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,28 @@
     "autoload": {
         "psr-4": { "GovTalk\\" : "src/" }
     },
+    "config": {
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "7.4.21"
+        },
+        "sort-packages": true
+    },
     "require": {
-        "php": ">=5.3.2",
-        "guzzle/guzzle": "~3.1"
+        "php": "^7.4 | ^8.0",
+        "ext-curl": "*",
+        "ext-dom": "*",
+        "ext-xmlwriter": "*",
+        "guzzlehttp/guzzle": "^7.3.0",
+        "psr/log": "^1.1.4"
     },
     "require-dev": {
-        "guzzle/plugin-mock": "~3.1",
-        "mockery/mockery": "~0.8",
-        "phpunit/phpunit": "~3.7.16",
-        "squizlabs/php_codesniffer": "~1.4"
+        "phpunit/phpunit": "^9.5.7",
+        "roave/security-advisories": "dev-master",
+        "squizlabs/php_codesniffer": "^3.6.0"
+    },
+    "scripts": {
+        "lint:check": "phpcs --standard=PSR2 src",
+        "test": "phpunit --coverage-text"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "justinbusschau/php-govtalk",
+    "name": "thebiggive/php-govtalk",
     "type": "library",
     "description": "A library for applications which interface with the UK Government Gateway",
-    "homepage": "https://github.com/justinbusschau/php-govtalk",
+    "homepage": "https://github.com/thebiggive/php-govtalk",
     "license": "GPLv3",
     "authors": [
         {
@@ -12,6 +12,11 @@
         {
             "name": "Justin Busschau",
             "email": "justin.busschau@gmail.com"
+        },
+        {
+            "name": "Noel Light-Hilary",
+            "email": "noel@thebiggive.org.uk",
+            "homepage": "https://noellh.com/"
         }
     ],
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="./tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="true">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="./tests/bootstrap.php"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        stopOnFailure="false"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+    <coverage>
+        <include>
+            <directory>./src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="PHP GovTalk Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/GovTalk.php
+++ b/src/GovTalk.php
@@ -1380,7 +1380,7 @@ class GovTalk implements LoggerAwareInterface
                 // Channel routing...
                 $channelRouteArray = $this->messageChannelRouting;
                 $channelRouteArray[] = array(
-                    'uri' => 'https://github.com/justinbusschau/php-govtalk/',
+                    'uri' => 'https://github.com/thebiggive/php-govtalk/',
                     'product' => 'php-govtalk',
                     'version' => self::VERSION,
                     'timestamp' => date('c')

--- a/tests/GovTalk/GovTalkTest.php
+++ b/tests/GovTalk/GovTalkTest.php
@@ -40,7 +40,7 @@ class GovTalkTest extends TestCase
     /**
      * Set up the test environment
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -71,18 +71,7 @@ class GovTalkTest extends TestCase
         $this->gtService = $this->setUpService();
     }
 
-    private function setUpService()
-    {
-        return new GovTalk(
-            $this->gatewayURL,
-            $this->gatewayUserID,
-            $this->gatewayUserPassword,
-            $this->getHttpClient(),
-            null
-        );
-    }
-
-    public function testSettingTestFlag()
+    public function testSettingTestFlag(): void
     {
         $this->assertTrue($this->gtService->setTestFlag(false));
         $this->assertFalse($this->gtService->getTestFlag());
@@ -94,7 +83,7 @@ class GovTalkTest extends TestCase
         $this->assertTrue($this->gtService->getTestFlag());
     }
 
-    public function testMessageAuthentication()
+    public function testMessageAuthentication(): void
     {
         $this->assertTrue($this->gtService->setMessageAuthentication('alternative'));
         $this->assertEquals($this->gtService->getMessageAuthentication(), 'alternative');
@@ -106,7 +95,7 @@ class GovTalkTest extends TestCase
         $this->assertEquals($this->gtService->getMessageAuthentication(), 'clear');
     }
 
-    public function testSettingEmailAddress()
+    public function testSettingEmailAddress(): void
     {
         $this->assertTrue($this->gtService->setSenderEmailAddress('jane@doeofjohn.com'));
         $this->assertEquals($this->gtService->getSenderEmailAddress(), 'jane@doeofjohn.com');
@@ -117,52 +106,52 @@ class GovTalkTest extends TestCase
         $this->assertTrue($this->gtService->setSenderEmailAddress('joe@bloggs.com'));
         $this->assertEquals($this->gtService->getSenderEmailAddress(), 'joe@bloggs.com');
     }
-    
-    public function testAddingMessageKey()
+
+    public function testAddingMessageKey(): void
     {
         $this->assertTrue($this->gtService->addMessageKey('VATRegNo', '999900001'));
         $this->assertFalse($this->gtService->addMessageKey(array('VATRegNo'), '999900001'));
     }
 
-    public function testDeletingMessageKey()
+    public function testDeletingMessageKey(): void
     {
         $this->assertTrue($this->gtService->addMessageKey('MyKey', '123456789'));
         $this->assertEquals($this->gtService->deleteMessageKey('MyKey'), 1);
     }
 
-    public function testResettingMessageKeys()
+    public function testResettingMessageKeys(): void
     {
         $this->assertTrue($this->gtService->addMessageKey('VATRegNo', '999900001'));
         $this->assertTrue($this->gtService->addMessageKey('MyKey', '123456789'));
         $this->assertTrue($this->gtService->resetMessageKeys());
     }
 
-    public function testSettingMessageClass()
+    public function testSettingMessageClass(): void
     {
         $this->assertFalse($this->gtService->setMessageClass('HVD'));
         $this->assertTrue($this->gtService->setMessageClass('HMRC-VAT-DEC'));
     }
 
-    public function testSettingMessageQualifier()
+    public function testSettingMessageQualifier(): void
     {
         $this->assertTrue($this->gtService->setMessageQualifier('error'));
         $this->assertFalse($this->gtService->setMessageQualifier('other'));
         $this->assertTrue($this->gtService->setMessageQualifier('request'));
     }
 
-    public function testSettingMessageFunction()
+    public function testSettingMessageFunction(): void
     {
         $this->assertTrue($this->gtService->setMessageFunction('submit'));
     }
 
-    public function testAddingChannelRoute()
+    public function testAddingChannelRoute(): void
     {
         $this->assertFalse($this->gtService->addChannelRoute(array('uri' => 'a', 'product' => 'b', 'version' => 'c')));
         $this->assertTrue($this->gtService->addChannelRoute('a', 'b', 'c', array(array('1','2','3')), '2014-04-04T12:28.123'));
         $this->assertTrue($this->gtService->addChannelRoute('d', 'e', 'f', null, '', true));
     }
 
-    public function testSettingMessageBody()
+    public function testSettingMessageBody(): void
     {
         $this->assertFalse($this->gtService->setMessageBody(array('')));
         $this->assertTrue($this->gtService->setMessageBody(new XMLWriter));
@@ -174,7 +163,7 @@ class GovTalkTest extends TestCase
         );
     }
 
-    public function testConstructAndSendMessage()
+    public function testConstructAndSendMessage(): void
     {
         $this->setMockHttpResponse('VatReturnAuthFailure.txt');
 
@@ -196,19 +185,19 @@ class GovTalkTest extends TestCase
         $this->assertTrue($this->gtService->responseHasErrors());
     }
 
-    public function testSendPrebuiltMessage()
+    public function testSendPrebuiltMessage(): void
     {
         $preBuiltMessage = $this->makeGiftAidSubmission();
         $this->assertSame($preBuiltMessage, $this->gtService->getFullXMLRequest());
         $this->assertTrue(is_string($this->gtService->getFullXMLResponse()));
     }
 
-    public function testGivenNoSubmission_getResponseQualifier_ReturnsFalse()
+    public function testGivenNoSubmission_getResponseQualifier_ReturnsFalse(): void
     {
         $this->assertFalse( $this->gtService->getResponseQualifier() );
     }
 
-    public function testGivenSubmission_getResponseQualifier_ReturnsAcknowledgement()
+    public function testGivenSubmission_getResponseQualifier_ReturnsAcknowledgement(): void
     {
         $this->makeGiftAidSubmission();
         $this->assertSame( GovTalk::QUALIFIER_ACKNOWLEDGEMENT, $this->gtService->getResponseQualifier() );
@@ -217,13 +206,27 @@ class GovTalkTest extends TestCase
     /**
      * @return string
      */
-    protected function makeGiftAidSubmission()
+    protected function makeGiftAidSubmission(): string
     {
-        $this->setMockHttpResponse( 'GiftAidResponseAck.txt' );
-        $preBuiltMessage = file_get_contents( __DIR__ . '/Messages/GiftAidRequest.txt' );
+        $this->setMockHttpResponse('GiftAidResponseAck.txt');
+        // Re-call this to actually replace the service with the one that has the non-empty
+        // mock response queue.
+        $this->gtService = $this->setUpService();
 
-        $this->gtService->sendMessage( $preBuiltMessage );
+        $preBuiltMessage = file_get_contents(__DIR__ . '/Messages/GiftAidRequest.txt');
+
+        $this->gtService->sendMessage($preBuiltMessage);
         return $preBuiltMessage;
+    }
+
+    private function setUpService(): GovTalk
+    {
+        return new GovTalk(
+            $this->gatewayURL,
+            $this->gatewayUserID,
+            $this->gatewayUserPassword,
+            $this->getHttpClient()
+        );
     }
 }
 

--- a/tests/GovTalk/Mock/GiftAidResponseAck.txt
+++ b/tests/GovTalk/Mock/GiftAidResponseAck.txt
@@ -1,6 +1,1 @@
-HTTP/1.1 200 OK
-Server: Apache-Coyote/1.1
-Content-Type: text/xml
-Content-Length:
-
 <?xml version="1.0"?><GovTalkMessage xmlns="http://www.govtalk.gov.uk/CM/envelope"><EnvelopeVersion>2.0</EnvelopeVersion><Header><MessageDetails><Class>HMRC-CHAR-CLM</Class><Qualifier>acknowledgement</Qualifier><Function>submit</Function><TransactionID></TransactionID><CorrelationID>6056640B42DD464688900F5A1CAC4A32</CorrelationID><ResponseEndPoint PollInterval="10">https://secure.dev.gateway.gov.uk/poll</ResponseEndPoint><GatewayTimestamp>2014-04-04T22:26:24.277</GatewayTimestamp></MessageDetails><SenderDetails/></Header><GovTalkDetails><Keys/></GovTalkDetails><Body></Body></GovTalkMessage>

--- a/tests/GovTalk/Mock/VatReturnAuthFailure.txt
+++ b/tests/GovTalk/Mock/VatReturnAuthFailure.txt
@@ -1,6 +1,1 @@
-HTTP/1.1 200 OK
-Connection: Keep-Alive
-Content-Length: 791
-Content-Type: text/xml; charset=utf-8
-
 <?xml version="1.0"?><GovTalkMessage xmlns="http://www.govtalk.gov.uk/CM/envelope"><EnvelopeVersion>2.0</EnvelopeVersion><Header><MessageDetails><Class>UndefinedClass</Class><Qualifier>error</Qualifier><Function>submit</Function><TransactionID></TransactionID><CorrelationID></CorrelationID><ResponseEndPoint PollInterval="10">https://secure.dev.gateway.gov.uk/poll</ResponseEndPoint><GatewayTimestamp>2014-04-05T23:56:32.142</GatewayTimestamp></MessageDetails><SenderDetails/></Header><GovTalkDetails><Keys/><GovTalkErrors><Error><RaisedBy>Gateway</RaisedBy><Number>1046</Number><Type>fatal</Type><Text>Authentication Failure. The supplied user credentials failed validation for the requested service.</Text><Location/></Error></GovTalkErrors></GovTalkDetails><Body></Body></GovTalkMessage>

--- a/tests/GovTalk/TestCase.php
+++ b/tests/GovTalk/TestCase.php
@@ -11,44 +11,48 @@
 
 namespace GovTalk;
 
-use PHPUnit_Framework_TestCase;
-use ReflectionObject;
-use Guzzle\Common\Event;
-use Guzzle\Http\Client as HttpClient;
-use Guzzle\Http\Message\RequestInterface as GuzzleRequestInterface;
-use Guzzle\Plugin\Mock\MockPlugin;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 
 /**
  * The Base class for all tests
  */
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    private $httpClient;
+    private ?Client $httpClient = null;
 
     /**
      * Create an instance of the Guzzle HTTP Client that we can
      * throw mocked responses into.
      */
-    public function getHttpClient()
+    public function getHttpClient(): Client
     {
         if ($this->httpClient === null) {
-            $this->httpClient = new HttpClient;
+            // Default to a mock handler with an empty response queue.
+            $this->httpClient = new Client([
+                'handler' => HandlerStack::create(new MockHandler()),
+            ]);
         }
 
         return $this->httpClient;
     }
 
     /**
-     * Mark a request as being mocked
+     * Set a mock response from a mock file for the next client request.
      *
-     * @param GuzzleRequestInterface $request
-     * @return self
+     * @param string  $path Path to the mock response file
+     *
+     * @link https://docs.guzzlephp.org/en/stable/testing.html#mock-handler
      */
-    public function addMockedHttpRequest(GuzzleRequestInterface $request)
+    public function setMockHttpResponse(string $path): void
     {
-        $this->mockHttpRequests[] = $request;
-
-        return $this;
+        $mock = new MockHandler([
+            $this->getMockHttpResponse($path),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $this->httpClient = new Client(['handler' => $handlerStack]);
     }
 
     /**
@@ -57,45 +61,8 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      * @param string $path Relative path to the mock response file
      * @return Response
      */
-    public function getMockHttpResponse($path)
+    protected function getMockHttpResponse(string $path): Response
     {
-        if ($path instanceof Response) {
-            return $path;
-        }
-
-        $ref = new ReflectionObject($this);
-        $dir = dirname($ref->getFileName());
-
-        // if mock file doesn't exist, check parent directory
-        if (!file_exists($dir.'/Mock/'.$path) && file_exists($dir.'/../Mock/'.$path)) {
-            return MockPlugin::getMockFile($dir.'/../Mock/'.$path);
-        }
-
-        return MockPlugin::getMockFile($dir.'/Mock/'.$path);
-    }
-
-    /**
-     * Set a mock response from a mock file for the next client request.
-     *
-     * @param string $paths Path to the mock response file
-     * @return MockPlugin returns the mock plugin
-     */
-    public function setMockHttpResponse($paths)
-    {
-        $this->mockHttpRequests = array();
-        $that = $this;
-        $mock = new MockPlugin(null, true);
-        $this->getHttpClient()->getEventDispatcher()->removeSubscriber($mock);
-        $mock->getEventDispatcher()->addListener('mock.request', function(Event $event) use ($that) {
-            $that->addMockedHttpRequest($event['request']);
-        });
-
-        foreach ((array) $paths as $path) {
-            $mock->addResponse($this->getMockHttpResponse($path));
-        }
-
-        $this->getHttpClient()->getEventDispatcher()->addSubscriber($mock);
-
-        return $mock;
+        return new Response(200, [], file_get_contents(__DIR__ . "/Mock/$path"));
     }
 }


### PR DESCRIPTION
* Update to modern libraries, including avoiding those with published security issues
* Add `roave/security-advisories` to check on update for future upstream library security issues
* Remove support for PHP versions no longer in active maintenance; add support for modern versions
* Replace non-binary safe `fopen()` calls with flexible PSR-3 log adapter support
* Make extension requirements explicit in `composer.json`
* Expand use of types and strict comparisons
* Other minor tidying, PSR-2 fixes & removal of some dead code
* Move to `thebiggive` namespace as per discussion on JustinBusschau#3 