### PR TITLE
Add `GatewayTimestamp`

### DIFF
--- a/src/GovTalk.php
+++ b/src/GovTalk.php
@@ -1291,6 +1291,7 @@ class GovTalk implements LoggerAwareInterface
                 $package->writeElement('CorrelationID', $this->messageCorrelationId);
                 $package->writeElement('Transformation', $this->messageTransformation);
                 $package->writeElement('GatewayTest', $this->govTalkTest);
+                $package->writeElement('GatewayTimestamp', date('c'));
 
                 /**
                  * When using the Local Test Service (LTS) you need to set a

--- a/tests/GovTalk/Messages/GiftAidRequest.txt
+++ b/tests/GovTalk/Messages/GiftAidRequest.txt
@@ -8,6 +8,7 @@
    <TransactionID>13873265714136</TransactionID>
    <Transformation>XML</Transformation>
    <GatewayTest>1</GatewayTest>
+   <GatewayTimestamp>2021-09-21T11:24:53+00:00</GatewayTimestamp>
   </MessageDetails>
   <SenderDetails>
    <IDAuthentication>


### PR DESCRIPTION
While this is optional, Gift Aid LTS tests failed with 'after today' errors
when it was omitted. For now, setting it to the server's current date/time
seems like the safest option.